### PR TITLE
Support diff-lcs v1.4+

### DIFF
--- a/lib/markdiff/operations/text_diff_operation.rb
+++ b/lib/markdiff/operations/text_diff_operation.rb
@@ -15,7 +15,7 @@ module Markdiff
       def inserted_node
         before_elements = target_node.to_s.split(" ")
         after_elements = @after_node.to_s.split(" ")
-        ::Diff::LCS.diff(before_elements, after_elements).flatten.each do |operation|
+        ::Diff::LCS.diff(before_elements, after_elements).flatten(1).each do |operation|
           type, position, element = *operation
           if type == "-"
             before_elements[position] = %(<del class="del">#{element}</del>)


### PR DESCRIPTION
> https://github.com/halostatue/diff-lcs/commit/a798f6f1dc5d41aceb236ea0aeaa113c8dc89c92

`Diff::LCS::Change` respond to `#to_ary` after v1.4, which causes TypeError on markdiff-0.6.2.

Here is a script to reproduce:

```ruby
require 'bundler/inline'

gemfile do
source 'https://rubygems.org'
# gem "diff-lcs", '1.3'
gem "diff-lcs", '1.4.4'
gem 'markdiff', '0.6.2'
end

puts "Ruby: #{RUBY_VERSION}"
puts "diff-lcs: v#{::Diff::LCS::VERSION}"

puts Markdiff::Differ.new.render('<p>a</p>', '<p>b</p>')
# diff-lcs: v1.3
# => <div class="changed"><p><del class="del">a</del><ins>b</ins></p></div>

# diff-lcs: v1.4.4
# => .../markdiff-0.6.2/lib/markdiff/operations/text_diff_operation.rb:21:in `[]=': no implicit conversion from nil to integer (TypeError)
```