### PR TITLE
Issue with long sentence

### DIFF
--- a/lib/markdiff/operations/text_diff_operation.rb
+++ b/lib/markdiff/operations/text_diff_operation.rb
@@ -17,23 +17,28 @@ module Markdiff
         after_elements = @after_node.to_s.split(' ')
         last_operation = nil
 
-        groupings = ::Diff::LCS.sdiff(before_elements, after_elements).slice_when {|prev, cur| prev.action != cur.action }
+        groupings = ::Diff::LCS.sdiff(before_elements, after_elements)
+          .slice_when { |prev, cur| prev.action != cur.action }
 
         output = groupings.map do |grouping|
-          response = case grouping.first.action
-          when "="
-            grouping.map(&:new_element).join(" ")
-          when "-"
-            %(<del class="del">#{grouping.map(&:old_element).join(" ")}</del>)
-          when "+"
-            %(<ins class="ins ins-before">#{grouping.map(&:new_element).join(" ")}</ins>)
-          when "!"
-            %(<del class="del">#{grouping.map(&:old_element).join(" ")}</del><ins class="ins ins-after">#{grouping.map(&:new_element).join(" ")}</ins>)
-        end
+          action = grouping.first.action
+
+          response = case action
+            when "="
+              grouping.map(&:new_element).join(" ")
+            when "-"
+              %(<del class="del">#{grouping.map(&:old_element).join(" ")}</del>)
+            when "+"
+              %(<ins class="ins ins-before">#{grouping.map(&:new_element).join(" ")}</ins>)
+            when "!"
+              %(<del class="del">#{grouping.map(&:old_element).join(" ")}</del><ins class="ins ins-after">#{grouping.map(&:new_element).join(" ")}</ins>)
+            else
+              raise "Unknown action #{action}"
+          end
 
           response = " #{response}" if last_operation && last_operation != '+'
 
-          last_operation = grouping.first.action
+          last_operation = action
 
           response
         end

--- a/lib/markdiff/operations/text_diff_operation.rb
+++ b/lib/markdiff/operations/text_diff_operation.rb
@@ -15,11 +15,12 @@ module Markdiff
       def inserted_node
         before_elements = target_node.to_s.split(' ')
         after_elements = @after_node.to_s.split(' ')
+        last_operation = nil
 
         groupings = ::Diff::LCS.sdiff(before_elements, after_elements).slice_when {|prev, cur| prev.action != cur.action }
 
         output = groupings.map do |grouping|
-          case grouping.first.action
+          response = case grouping.first.action
           when "="
             grouping.map(&:new_element).join(" ")
           when "-"
@@ -28,10 +29,16 @@ module Markdiff
             "<ins class=\"ins ins-before\">#{grouping.map(&:new_element).join(" ")}</ins>"
           when "!"
             "<del class=\"del\">#{grouping.map(&:old_element).join(" ")}</del><ins class=\"ins ins-after\">#{grouping.map(&:new_element).join(" ")}</ins>"
-          end
         end
 
-        ::Nokogiri::HTML.fragment(output.join(' '))
+          response = " #{response}" if last_operation && last_operation != '+'
+
+          last_operation = grouping.first.action
+
+          response
+        end
+
+        ::Nokogiri::HTML.fragment(output.join(''))
       end
 
       def priority

--- a/lib/markdiff/operations/text_diff_operation.rb
+++ b/lib/markdiff/operations/text_diff_operation.rb
@@ -33,7 +33,7 @@ module Markdiff
             end if insertion_start
         end
 
-        ::Nokogiri::HTML.fragment(before_elements.reject(&:empty?).join(' '))
+        ::Nokogiri::HTML.fragment(before_elements.reject(&:nil?).join(' '))
       end
 
       def priority

--- a/lib/markdiff/operations/text_diff_operation.rb
+++ b/lib/markdiff/operations/text_diff_operation.rb
@@ -35,6 +35,9 @@ module Markdiff
           end
 
           before_elements[deletions.first.position] = %(<del class="del">#{deletions.map(&:element).join(" ")}</del>) if deletions.length.positive?
+          deletions[1..]&.each { |action, position, _| before_elements[position] = "" }
+
+          pp "additions are: #{additions.map(&:element)}"
 
           if additions.length.positive?
             if deletions.first&.position == additions.first.position
@@ -45,7 +48,7 @@ module Markdiff
           end
         end
 
-        ::Nokogiri::HTML.fragment(before_elements.join(' '))
+        ::Nokogiri::HTML.fragment(before_elements.reject(&:empty?).join(' '))
       end
 
       def priority

--- a/lib/markdiff/operations/text_diff_operation.rb
+++ b/lib/markdiff/operations/text_diff_operation.rb
@@ -24,11 +24,11 @@ module Markdiff
           when "="
             grouping.map(&:new_element).join(" ")
           when "-"
-            "<del class=\"del\">#{grouping.map(&:old_element).join(" ")}</del>"
+            %(<del class="del">#{grouping.map(&:old_element).join(" ")}</del>)
           when "+"
-            "<ins class=\"ins ins-before\">#{grouping.map(&:new_element).join(" ")}</ins>"
+            %(<ins class="ins ins-before">#{grouping.map(&:new_element).join(" ")}</ins>)
           when "!"
-            "<del class=\"del\">#{grouping.map(&:old_element).join(" ")}</del><ins class=\"ins ins-after\">#{grouping.map(&:new_element).join(" ")}</ins>"
+            %(<del class="del">#{grouping.map(&:old_element).join(" ")}</del><ins class="ins ins-after">#{grouping.map(&:new_element).join(" ")}</ins>)
         end
 
           response = " #{response}" if last_operation && last_operation != '+'

--- a/spec/markdiff/differ_spec.rb
+++ b/spec/markdiff/differ_spec.rb
@@ -287,7 +287,7 @@ RSpec.describe Markdiff::Differ do
 
       it "returns the expected patched text" do
         expect(subject.to_html)
-          .to eq '<div class="changed"><div>Kurset skal give de studerende <ins class="ins ins-before">TEST</ins>procesforståelse samt teoretisk og praktisk erfaring.</div></div>'
+          .to eq '<div class="changed"><div>Kurset skal give de studerende <ins class="ins ins-before">TEST</ins> procesforståelse samt teoretisk og praktisk erfaring.</div></div>'
       end
     end
 
@@ -301,7 +301,7 @@ RSpec.describe Markdiff::Differ do
 
       it "returns the expected patched node" do
         expect(subject.to_html)
-          .to eq '<ins class="ins ins-before">Det</ins>Kurset skal give de studerende procesforståelse samt teoretisk og praktisk erfaring.'
+          .to eq '<ins class="ins ins-before">Det</ins> Kurset skal give de studerende procesforståelse samt teoretisk og praktisk erfaring.'
       end
     end
 
@@ -353,7 +353,7 @@ RSpec.describe Markdiff::Differ do
 
       it 'returns expected patched node' do
         expect(subject.to_html)
-          .to eq '<ins class="ins ins-before">JEG HEDDER</ins>Kurset <del class="del">skal</del> give de studerende procesforståelse'
+          .to eq '<ins class="ins ins-before">JEG HEDDER</ins> Kurset <del class="del">skal</del> give de studerende procesforståelse'
       end
     end
 
@@ -366,11 +366,25 @@ RSpec.describe Markdiff::Differ do
       end
 
       it "returns the expected patched note" do
-        expect(subject.to_html).to eq 'Der gælder for specialer udført ved <del class="del">Science &amp; Technology,</del><ins class="ins ins-after">Faculty of Natural Sciences og Faculty of Technical Sciences,</ins> Et Universitet. Hovedvejleder har det formelle ansvar for den faglige vejledning.'
+        expect(subject.to_html).to eq 'Der gælder for specialer udført ved <del class="del">Science &amp; Technology,</del><ins class="ins ins-after">Faculty of Natural</ins> <ins class="ins ins-before">Sciences og Faculty of Technical Sciences,</ins> Et Universitet. Hovedvejleder har det formelle ansvar for den faglige vejledning.'
       end
     end
 
     context "with even more changes" do
+      let(:after_string) do
+        "De matematiske begreber i kurset kommer først og fremmest til at blive underbygget af små eksperimenter i programmeringssprogene php, Sage og ruby."
+      end
+      let(:before_string) do
+        "De matematiske slettet begreber i kurset kommer først og fremmest til at blive underbygget af små eksperimenter i programmeringssprogene Sage og python."
+      end
+
+      it "returns the expected patched note" do
+        expect(subject.to_html)
+          .to eq 'De matematiske <del class="del">slettet</del> begreber i kurset kommer først og fremmest til at blive underbygget af små eksperimenter i programmeringssprogene <ins class="ins ins-before">php,</ins> Sage og <del class="del">python.</del><ins class="ins ins-after">ruby.</ins>'
+      end
+    end
+
+    context "with weird changes" do
       let(:after_string) do
         "De matematiske begreber kommer først og fremmest i kurset vil blive underbygget af små eksperimenter i programmeringssprogene php, Sage og ruby."
       end
@@ -379,7 +393,7 @@ RSpec.describe Markdiff::Differ do
       end
 
       it "returns the expected patched note" do
-        expect(subject.to_html).to eq 'De matematiske <del class="del">asd</del> begreber <ins class="ins ins-after">kommer først og fremmest</ins> i kurset vil blive underbygget af små eksperimenter i programmeringssprogene Sage og <del class="del">python.</del> <ins class="ins ins-before">php,</ins> <ins class="ins ins-before">ruby.</ins>'
+        expect(subject.to_html).to eq 'De matematiske <del class="del">asd</del> begreber <ins class="ins ins-before">kommer først og fremmest</ins> i kurset vil blive underbygget af små eksperimenter i programmeringssprogene <ins class="ins ins-before">php,</ins> Sage og <del class="del">python.</del><ins class="ins ins-after">ruby.</ins>'
       end
     end
   end

--- a/spec/markdiff/differ_spec.rb
+++ b/spec/markdiff/differ_spec.rb
@@ -287,7 +287,7 @@ RSpec.describe Markdiff::Differ do
 
       it "returns the expected patched text" do
         expect(subject.to_html)
-          .to eq '<div class="changed"><div>Kurset skal give de studerende <ins class="ins ins-before">TEST</ins> procesforståelse samt teoretisk og praktisk erfaring.</div></div>'
+          .to eq '<div class="changed"><div>Kurset skal give de studerende <ins class="ins ins-before">TEST</ins>procesforståelse samt teoretisk og praktisk erfaring.</div></div>'
       end
     end
 
@@ -301,7 +301,7 @@ RSpec.describe Markdiff::Differ do
 
       it "returns the expected patched node" do
         expect(subject.to_html)
-          .to eq '<ins class="ins ins-before">Det</ins> Kurset skal give de studerende procesforståelse samt teoretisk og praktisk erfaring.'
+          .to eq '<ins class="ins ins-before">Det</ins>Kurset skal give de studerende procesforståelse samt teoretisk og praktisk erfaring.'
       end
     end
 
@@ -352,8 +352,7 @@ RSpec.describe Markdiff::Differ do
       let(:before_string) { "Kurset skal give de studerende procesforståelse" }
 
       it 'returns expected patched node' do
-        expect(subject.to_html)
-          .to eq '<ins class="ins ins-before">JEG HEDDER</ins> Kurset <del class="del">skal</del> give de studerende procesforståelse'
+        expect(subject.to_html).to eq '<ins class="ins ins-before">JEG HEDDER</ins>Kurset <del class="del">skal</del> give de studerende procesforståelse'
       end
     end
 
@@ -366,7 +365,7 @@ RSpec.describe Markdiff::Differ do
       end
 
       it "returns the expected patched note" do
-        expect(subject.to_html).to eq 'Der gælder for specialer udført ved <del class="del">Science &amp; Technology,</del><ins class="ins ins-after">Faculty of Natural</ins> <ins class="ins ins-before">Sciences og Faculty of Technical Sciences,</ins> Et Universitet. Hovedvejleder har det formelle ansvar for den faglige vejledning.'
+        expect(subject.to_html).to eq 'Der gælder for specialer udført ved <del class="del">Science &amp; Technology,</del><ins class="ins ins-after">Faculty of Natural</ins> <ins class="ins ins-before">Sciences og Faculty of Technical Sciences,</ins>Et Universitet. Hovedvejleder har det formelle ansvar for den faglige vejledning.'
       end
     end
 
@@ -380,7 +379,7 @@ RSpec.describe Markdiff::Differ do
 
       it "returns the expected patched note" do
         expect(subject.to_html)
-          .to eq 'De matematiske <del class="del">slettet</del> begreber i kurset kommer først og fremmest til at blive underbygget af små eksperimenter i programmeringssprogene <ins class="ins ins-before">php,</ins> Sage og <del class="del">python.</del><ins class="ins ins-after">ruby.</ins>'
+          .to eq 'De matematiske <del class="del">slettet</del> begreber i kurset kommer først og fremmest til at blive underbygget af små eksperimenter i programmeringssprogene <ins class="ins ins-before">php,</ins>Sage og <del class="del">python.</del><ins class="ins ins-after">ruby.</ins>'
       end
     end
 
@@ -393,7 +392,7 @@ RSpec.describe Markdiff::Differ do
       end
 
       it "returns the expected patched note" do
-        expect(subject.to_html).to eq 'De matematiske <del class="del">asd</del> begreber <ins class="ins ins-before">kommer først og fremmest</ins> i kurset vil blive underbygget af små eksperimenter i programmeringssprogene <ins class="ins ins-before">php,</ins> Sage og <del class="del">python.</del><ins class="ins ins-after">ruby.</ins>'
+        expect(subject.to_html).to eq 'De matematiske <del class="del">asd</del> begreber <ins class="ins ins-before">kommer først og fremmest</ins>i kurset vil blive underbygget af små eksperimenter i programmeringssprogene <ins class="ins ins-before">php,</ins>Sage og <del class="del">python.</del><ins class="ins ins-after">ruby.</ins>'
       end
     end
   end

--- a/spec/markdiff/differ_spec.rb
+++ b/spec/markdiff/differ_spec.rb
@@ -369,5 +369,18 @@ RSpec.describe Markdiff::Differ do
         expect(subject.to_html).to eq 'Der gælder for specialer udført ved <del class="del">Science &amp; Technology,</del><ins class="ins ins-after">Faculty of Natural Sciences og Faculty of Technical Sciences,</ins> Et Universitet. Hovedvejleder har det formelle ansvar for den faglige vejledning.'
       end
     end
+
+    context "with even more changes" do
+      let(:after_string) do
+        "De matematiske begreber kommer først og fremmest i kurset vil blive underbygget af små eksperimenter i programmeringssprogene php, Sage og ruby."
+      end
+      let(:before_string) do
+        "De matematiske asd begreber i kurset vil blive underbygget af små eksperimenter i programmeringssprogene Sage og python."
+      end
+
+      it "returns the expected patched note" do
+        expect(subject.to_html).to eq 'De matematiske <del class="del">asd</del> begreber <ins class="ins ins-after">kommer først og fremmest</ins> i kurset vil blive underbygget af små eksperimenter i programmeringssprogene Sage og <del class="del">python.</del> <ins class="ins ins-before">php,</ins> <ins class="ins ins-before">ruby.</ins>'
+      end
+    end
   end
 end

--- a/spec/markdiff/differ_spec.rb
+++ b/spec/markdiff/differ_spec.rb
@@ -351,8 +351,9 @@ RSpec.describe Markdiff::Differ do
       let(:after_string) { "JEG HEDDER Kurset give de studerende procesforståelse" }
       let(:before_string) { "Kurset skal give de studerende procesforståelse" }
 
-      it "returns expected patched node" do
-        expect(subject.to_html).to eq '<ins class="ins ins-before">JEG</ins>Kurset <del class="del">skal</del><ins class="ins ins-after">HEDDER</ins> give de studerende procesforståelse'
+      it 'returns expected patched node' do
+        expect(subject.to_html)
+          .to eq '<ins class="ins ins-before">JEG HEDDER</ins>Kurset <del class="del">skal</del> give de studerende procesforståelse'
       end
     end
 

--- a/spec/markdiff/differ_spec.rb
+++ b/spec/markdiff/differ_spec.rb
@@ -355,5 +355,18 @@ RSpec.describe Markdiff::Differ do
         expect(subject.to_html).to eq '<ins class="ins ins-before">JEG</ins>Kurset <del class="del">skal</del><ins class="ins ins-after">HEDDER</ins> give de studerende procesforståelse'
       end
     end
+
+    context "with lots of changes" do
+      let(:after_string) do
+        "Der gælder for specialer udført ved Faculty of Natural Sciences og Faculty of Technical Sciences, Et Universitet. Hovedvejleder har det formelle ansvar for den faglige vejledning."
+      end
+      let(:before_string) do
+        "Der gælder for specialer udført ved Science & Technology, Et Universitet. Hovedvejleder har det formelle ansvar for den faglige vejledning."
+      end
+
+      it "returns the expected patched note" do
+        expect(subject.to_html).to eq 'Der gælder for specialer udført ved <del class="del">Science</del><ins class="ins ins-after">Faculty</ins> <del class="del">&amp;</del><ins class="ins ins-after">of</ins> <del class="del">Technology,</del><ins class="ins ins-after">Natural</ins> <ins class="ins ins-before">Sciences</ins>Et <ins class="ins ins-before">og</ins>Universitet. <ins class="ins ins-before">Faculty of Technical Sciences</ins>Hovedvejleder har formelle ansvar for den faglige vejledning.'
+      end
+    end
   end
 end

--- a/spec/markdiff/differ_spec.rb
+++ b/spec/markdiff/differ_spec.rb
@@ -366,7 +366,7 @@ RSpec.describe Markdiff::Differ do
       end
 
       it "returns the expected patched note" do
-        expect(subject.to_html).to eq 'Der gælder for specialer udført ved <del class="del">Science</del><ins class="ins ins-after">Faculty</ins> <del class="del">&amp;</del><ins class="ins ins-after">of</ins> <del class="del">Technology,</del><ins class="ins ins-after">Natural</ins> <ins class="ins ins-before">Sciences</ins>Et <ins class="ins ins-before">og</ins>Universitet. <ins class="ins ins-before">Faculty of Technical Sciences</ins>Hovedvejleder har formelle ansvar for den faglige vejledning.'
+        expect(subject.to_html).to eq 'Der gælder for specialer udført ved <del class="del">Science &amp; Technology,</del><ins class="ins ins-after">Faculty of Natural Sciences og Faculty of Technical Sciences,</ins> Et Universitet. Hovedvejleder har det formelle ansvar for den faglige vejledning.'
       end
     end
   end

--- a/spec/markdiff/differ_spec.rb
+++ b/spec/markdiff/differ_spec.rb
@@ -365,25 +365,12 @@ RSpec.describe Markdiff::Differ do
       end
 
       it "returns the expected patched note" do
-        expect(subject.to_html).to eq 'Der gælder for specialer udført ved <del class="del">Science &amp; Technology,</del><ins class="ins ins-after">Faculty of Natural</ins> <ins class="ins ins-before">Sciences og Faculty of Technical Sciences,</ins>Et Universitet. Hovedvejleder har det formelle ansvar for den faglige vejledning.'
-      end
-    end
-
-    context "with even more changes" do
-      let(:after_string) do
-        "De matematiske begreber i kurset kommer først og fremmest til at blive underbygget af små eksperimenter i programmeringssprogene php, Sage og ruby."
-      end
-      let(:before_string) do
-        "De matematiske slettet begreber i kurset kommer først og fremmest til at blive underbygget af små eksperimenter i programmeringssprogene Sage og python."
-      end
-
-      it "returns the expected patched note" do
         expect(subject.to_html)
-          .to eq 'De matematiske <del class="del">slettet</del> begreber i kurset kommer først og fremmest til at blive underbygget af små eksperimenter i programmeringssprogene <ins class="ins ins-before">php,</ins>Sage og <del class="del">python.</del><ins class="ins ins-after">ruby.</ins>'
+          .to eq 'Der gælder for specialer udført ved <del class="del">Science &amp; Technology,</del><ins class="ins ins-after">Faculty of Natural</ins> <ins class="ins ins-before">Sciences og Faculty of Technical Sciences,</ins>Et Universitet. Hovedvejleder har det formelle ansvar for den faglige vejledning.'
       end
     end
 
-    context "with weird changes" do
+    context "with a long sentence" do
       let(:after_string) do
         "De matematiske begreber kommer først og fremmest i kurset vil blive underbygget af små eksperimenter i programmeringssprogene php, Sage og ruby."
       end
@@ -392,7 +379,8 @@ RSpec.describe Markdiff::Differ do
       end
 
       it "returns the expected patched note" do
-        expect(subject.to_html).to eq 'De matematiske <del class="del">asd</del> begreber <ins class="ins ins-before">kommer først og fremmest</ins>i kurset vil blive underbygget af små eksperimenter i programmeringssprogene <ins class="ins ins-before">php,</ins>Sage og <del class="del">python.</del><ins class="ins ins-after">ruby.</ins>'
+        expect(subject.to_html)
+          .to eq 'De matematiske <del class="del">asd</del> begreber <ins class="ins ins-before">kommer først og fremmest</ins>i kurset vil blive underbygget af små eksperimenter i programmeringssprogene <ins class="ins ins-before">php,</ins>Sage og <del class="del">python.</del><ins class="ins ins-after">ruby.</ins>'
       end
     end
   end


### PR DESCRIPTION
This (hopefully) fixes issues with long sentences by using sdiff rather than diff, since this way we don't have to account for indices getting out of sync between after and before elements. I've tested this on some rather large text portions as well and it seems to have fixed a lot of the issues that we've had :-)